### PR TITLE
fix: pip needs -r option to install from file

### DIFF
--- a/PYTHON-SETUP.md
+++ b/PYTHON-SETUP.md
@@ -28,7 +28,7 @@ Once all the CUDA requirements are installed, create a `virtualenv` on your syst
 ```bash
     virtualenv -p python3.7 /path/to/venv_pt 
     source /path/to/venv_pt/bin/activate
-    pip install requirements_pytorch_gpu.txt
+    pip install -r requirements_pytorch_gpu.txt
 ```
 
 To test if PyTorch is able to properly access the GPU, start a Python session through the virtual environment create above and run the following commands:
@@ -58,7 +58,7 @@ Once all the CUDA requirements are installed, create a `virtualenv` on your syst
 ```bash
     virtualenv -p python3.7 /path/to/venv_tf
     source /path/to/venv_tf/bin/activate
-    pip install requirements_tensorflow_gpu.txt
+    pip install -r requirements_tensorflow_gpu.txt
 ```
 
 **Note:** the `virtualenv` may need to set the Python version to `3.7` to be compatible with TensorFlow version `2.2`.

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To learn more about multi-replica, please visit the developer doc page on the sa
 | BERT (fine-tuning) Named Entity Recognition | [TensorFlow code](./modelzoo/transformers/tf/bert/fine_tuning/token_classifier/)<br>[PyTorch code](./modelzoo/transformers/pytorch/bert/fine_tuning/token_classifier/) | - |
 | BERT (fine-tuning) Summarization | [TensorFlow code](./modelzoo/transformers/tf/bert/fine_tuning/extractive_summarization/)<br>[PyTorch code](./modelzoo/transformers/pytorch/bert/fine_tuning/extractive_summarization/) | - |
 | BERT (fine-tuning) Question Answering | [TensorFlow code](./modelzoo/transformers/tf/bert/fine_tuning/qa/)<br>[PyTorch code](./modelzoo/transformers/pytorch/bert/fine_tuning/qa/) | - |
-| GPT-2 | [TensorFlow code](./modelzoo/transformers/tf/gpt2/)<br>[PyTorch code](./modelzoo/transformers/pytorch/gpt2/) | [TensorFlow code](./modelzoo/transformers/tf/gpt2/) |
+| GPT-2 | [TensorFlow code](./modelzoo/transformers/tf/gpt2/)<br>[PyTorch code](./modelzoo/transformers/pytorch/gpt2/) | [TensorFlow code](./modelzoo/transformers/tf/gpt2/)<br>[PyTorch code](./modelzoo/transformers/pytorch/gpt2/) |
 | GPT-3 | - | [TensorFlow code](./modelzoo/transformers/tf/gpt3/) |
 | GPT-J | - | [TensorFlow code](./modelzoo/transformers/tf/gptj/) |
 | GPT-J (fine-tuning) Summarization | - | [TensorFlow code](./modelzoo/transformers/tf/gptj/fine_tuning/abstractive_summarization/) |

--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -2,6 +2,11 @@
 
 The following are the release notes for the Model Zoo repository.
 
+## Version 1.6.1
+
+- First Weight Streaming model support for PyTorch GPT2 XL model as an early access.
+- Improvements on Pipeline Legacy flow using Kubernetes and appliance mode.
+
 ## Version 1.6.0
 
 ### New features and enhancements

--- a/modelzoo/common/pytorch/PyTorchBaseModel.py
+++ b/modelzoo/common/pytorch/PyTorchBaseModel.py
@@ -76,9 +76,10 @@ class PyTorchBaseModel(ABC):
         self.mixed_precision = params["model"]["mixed_precision"]
 
         # Whether or not to allow multireplica runs
+        # default to false for eval runs.
         self.allow_multireplica = params["model"].get(
             "allow_multireplica", True
-        )
+        ) and self.mode == "train"
 
         seed = params["runconfig"].get("seed", None)
         if seed is not None:

--- a/modelzoo/common/pytorch/pytorch_base_runner.py
+++ b/modelzoo/common/pytorch/pytorch_base_runner.py
@@ -902,7 +902,19 @@ class PyTorchBaseRunner(metaclass=abc.ABCMeta):
         """
         runconfig_params = params["runconfig"]
 
-        cs_ip = runconfig_params["cs_ip"]
+        # For k8s flow, cs_ip is determined based on our custom scheduler. When K8S_CS_IP
+        # is set, we use its value as cs_ip. We raise an error if cs_ip is set in the runconfig.
+        k8s_cs_ip = os.environ.get("K8S_CS_IP", None)
+        if k8s_cs_ip:
+            if runconfig_params["cs_ip"] is not None:
+                raise ValueError(
+                    "cs_ip is determined internally and should not be specified"
+                )
+            cs_ip = k8s_cs_ip
+            logging.info(f"Setting cs_ip to: {cs_ip}")
+        else:
+            cs_ip = runconfig_params["cs_ip"]
+
         if (
             runconfig_params["compile_only"]
             and runconfig_params["validate_only"]

--- a/modelzoo/common/pytorch/utils.py
+++ b/modelzoo/common/pytorch/utils.py
@@ -87,6 +87,13 @@ def update_params_from_args(args: argparse.Namespace, params: dict):
             "'--checkpoint_path' is provided."
         )
 
+    mode = params.get("mode")
+    if mode != "train" and params.get("multireplica"):
+        logging.warning(
+            f"Multireplica is only supported in `train` mode. Disabling it for "
+            f"{mode} mode."
+        )
+
     model_dir = params["model_dir"]
     os.makedirs(model_dir, exist_ok=True)
     params.setdefault("service_dir", model_dir)

--- a/modelzoo/common/tf/appliance_utils.py
+++ b/modelzoo/common/tf/appliance_utils.py
@@ -22,7 +22,11 @@ import argparse
 import os
 
 from cerebras_appliance.pb.client.common_config_pb2 import DebugArgs
-from modelzoo.common.tf.run_utils import get_params, update_params_from_args
+from modelzoo.common.tf.run_utils import (
+    get_params,
+    save_params,
+    update_params_from_args,
+)
 
 
 def get_debug_args(debug_ini_path):
@@ -148,5 +152,6 @@ def parse_args_and_params(
 
     runconfig_params = params["runconfig"]
     update_params_from_args(args, runconfig_params)
+    save_params(params, model_dir=runconfig_params["model_dir"])
 
     return params

--- a/modelzoo/common/tf/run_utils.py
+++ b/modelzoo/common/tf/run_utils.py
@@ -80,9 +80,14 @@ def is_cs(params):
     Check if the runtime enviroment is that of a Cerebras System.
     If yes, return True, else False
 
+    For legacy k8s flow, the user does not need to specify cs_ip, since k8s
+    schedule determines which CS system to use internally. When a CS
+    is needed for the run, K8S_CS_IP will be set. This functions returns
+    true if K8S_CS_IP is set.
+
     :param dict params: runconfig dict to provide parameters for check
     """
-    return params.get("cs_ip") is not None
+    return params.get("cs_ip") is not None or os.environ.get("K8S_CS_IP", None) is not None
 
 
 def check_env(params):
@@ -207,7 +212,10 @@ def update_params_from_args(args, params):
             params["eval_steps"] = None
 
     # setting cs_ip based on is_cs
-    params["cs_ip"] = params["cs_ip"] + ":9000" if is_cs(params) else None
+    if not is_cs(params):
+        params["cs_ip"] = None
+    elif os.environ.get("K8S_CS_IP", None) is None:
+        params["cs_ip"] = params["cs_ip"] + ":9000"
 
 
 #######################################

--- a/modelzoo/transformers/pytorch/gpt2/README.md
+++ b/modelzoo/transformers/pytorch/gpt2/README.md
@@ -132,7 +132,8 @@ In order to train the model, you need to provide a yaml config file. Some popula
 
 - `params_gpt2_small.yaml` have the standard gpt2-base config with `hidden_size=768`, `num_hidden_layers=12`, `num_heads=12`
 - `params_gpt2_medium.yaml` have the standard gpt2-medium config with `hidden_size=1024`, `num_hidden_layers=24`, `num_heads=16`
-- `params_gpt2_large.yaml` have the standard gpt2-medium config with `hidden_size=1280`, `num_hidden_layers=36`, `num_heads=20`
+- `params_gpt2_large.yaml` have the standard gpt2-large config with `hidden_size=1280`, `num_hidden_layers=36`, `num_heads=20`
+- `params_gpt2_xl_ws_early_access.yaml` have the standard gpt2-extra large config (The GPT2) with `hidden_size=1600`, `num_hidden_layers=48`, `num_heads=16`. Works in Weight Streaming mode.
 
 All configs are meant to be run on Pipeline mode using Appliance mode and Kubernetes flow. Slurm workflow is available as a legacy support.
 

--- a/modelzoo/transformers/pytorch/gpt2/configs/params_gpt2_xl_ws_early_access.yaml
+++ b/modelzoo/transformers/pytorch/gpt2/configs/params_gpt2_xl_ws_early_access.yaml
@@ -1,0 +1,89 @@
+# GPT-2 X Large 48-layer, 1600-hidden, 16-heads, 1.5B parameters.
+# https://huggingface.co/gpt2-xl/blob/main/config.json
+# https://d4mucfpksywv.cloudfront.net/better-language-models/language_models_are_unsupervised_multitask_learners.pdf
+train_input:
+    data_processor: "GptHDF5DataProcessor"
+    data_dir: "./owt_pretraining_gpt_hdf5/train_8M_msl1024/"
+    vocab_size: 50257
+    max_sequence_length: 1024
+    # For high utilization in weight streaming, we estimate batch size >96 seqs
+    batch_size: 95
+    shuffle: True
+    shuffle_seed: 1337
+    num_workers: 8
+    prefetch_factor: 10
+    persistent_workers: True # Important to avoid seeding at each epoch
+    repeat: True
+
+eval_input:
+    data_processor: "GptHDF5DataProcessor"
+    data_dir: "./owt_pretraining_gpt_hdf5/val_msl1024/"
+    vocab_size: 50257
+    max_sequence_length: 1024
+    batch_size: 95
+    shuffle: False
+    num_workers: 8
+    prefetch_factor: 10
+    persistent_workers: True # Important to avoid seeding at each epoch
+
+model:
+    # Embedding
+    vocab_size: 50257
+    hidden_size: 1600
+    use_position_embedding: True
+    position_embedding_type: "learned"
+    share_embedding_weights: True
+    max_position_embeddings: 1024
+
+    # Encoder
+    num_hidden_layers: 48
+    dropout_rate: 0.1 # https://huggingface.co/transformers/v3.0.2/model_doc/gpt2.html
+    # https://huggingface.co/gpt2-xl/blob/main/config.json#L11 Since OpenAI did not share this setting
+    layer_norm_epsilon: 1.0e-5 # change to 1.0e-12 for single precision training
+    
+
+    # Encoder - Attention
+    num_heads: 16  # it was confirmed with authors that in fact it is 16 not 25
+    attention_type: "scaled_dot_product"
+    attention_dropout_rate: 0.1 # https://huggingface.co/transformers/v3.0.2/model_doc/gpt2.html
+    # following attention & ffn biases are set using https://amaarora.github.io/2020/02/18/annotatedGPT2.html
+    use_projection_bias_in_attention: True
+    use_ffn_bias_in_attention: True
+
+    # Encoder - ffn
+    filter_size: 6400 # hidden_size * 4
+    nonlinearity: "gelu"
+    use_ffn_bias: True
+    use_bias_in_output: False # As used in https://amaarora.github.io/2020/02/18/annotatedGPT2.html
+
+    # Cerebras parameters
+    mixed_precision: True
+    allow_multireplica: False
+
+optimizer:
+    optimizer_type: "AdamW"
+    correct_bias: True
+    weight_decay_rate: 0.011 # https://nostalgebraist.tumblr.com/post/642136680709652480/gpt2s-weight-decay/amp
+    beta1: 0.9
+    beta2: 0.999
+    learning_rate:
+        - scheduler: "Linear"
+          initial_learning_rate: 0.0
+          steps: 30838 # 3083878 * 0.01(warmup) 
+          end_learning_rate: 4.3e-5 # sqrt(95 / 512) * 0.0001
+        - scheduler: "CosineDecay"
+          initial_learning_rate: 4.3e-5 # sqrt(95 / 512) * 0.0001
+          end_learning_rate: 4.3e-6 # 4.3e-5 * (1.0 - 0.9)
+          decay_steps: 3053040 # 3083878 - 30838
+    loss_scaling_factor: "dynamic"
+    max_gradient_norm: 1.0
+
+runconfig:
+    max_steps: 3083878 # 300000000000 / (1024 * 512) * 512 / 95
+    log_steps: 100
+    checkpoint_steps: 10000
+    save_initial_checkpoint: True
+    seed: 1
+    show_debug_metrics: False
+    save_losses: True
+    eval_steps: 528 # 50257 / 95 - 1

--- a/modelzoo/transformers/pytorch/t5/configs/t5_base.yaml
+++ b/modelzoo/transformers/pytorch/t5/configs/t5_base.yaml
@@ -90,7 +90,7 @@ runconfig:
     max_steps: 524288
     log_steps: 100
     checkpoint_steps: 10000
-    eval_steps: 24000
+    eval_steps: 2510
     seed: 1
     model_dir: "./model_dir"
     show_debug_metrics: False

--- a/modelzoo/transformers/pytorch/t5/configs/t5_small.yaml
+++ b/modelzoo/transformers/pytorch/t5/configs/t5_small.yaml
@@ -86,7 +86,7 @@ runconfig:
     max_steps: 524288
     log_steps: 100
     checkpoint_steps: 10000
-    eval_steps: 24000
+    eval_steps: 2510
     seed: 1
     model_dir: "./model_dir"
     show_debug_metrics: False

--- a/modelzoo/transformers/tf/bert/data.py
+++ b/modelzoo/transformers/tf/bert/data.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.bert.input.BertMlmOnlyTfRecordsDynamicMaskProcessor import (  # noqa
     BertMlmOnlyTfRecordsDynamicMaskProcessor,
 )

--- a/modelzoo/transformers/tf/gpt2/data.py
+++ b/modelzoo/transformers/tf/gpt2/data.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.gpt2.input.GptTfRecordsProcessor import (  # noqa
     GptTfRecordsProcessor,
 )

--- a/modelzoo/transformers/tf/gptj/data.py
+++ b/modelzoo/transformers/tf/gptj/data.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.gpt2.input.GptTfRecordsProcessor import (  # noqa
     GptTfRecordsProcessor,
 )

--- a/modelzoo/transformers/tf/linformer/data.py
+++ b/modelzoo/transformers/tf/linformer/data.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.bert.input.BertMlmOnlyTfRecordsDynamicMaskProcessor import (  # noqa
     BertMlmOnlyTfRecordsDynamicMaskProcessor,
 )

--- a/modelzoo/transformers/tf/t5/data.py
+++ b/modelzoo/transformers/tf/t5/data.py
@@ -14,10 +14,12 @@
 
 """ Data input for T5. """
 
+import os
 import sys
 
 import tensorflow as tf
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.t5.input.T5DynamicDataProcessor import (  # noqa
     T5DynamicDataProcessor,
 )

--- a/modelzoo/transformers/tf/transformer/data.py
+++ b/modelzoo/transformers/tf/transformer/data.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import sys
 
 import tensorflow as tf
 
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../../.."))
 from modelzoo.transformers.tf.transformer.input.TransformerDynamicDataProcessor import (  # noqa
     TransformerDynamicDataProcessor,
 )


### PR DESCRIPTION
`-r` stands for `requirement`. 
Use `pip install <file.txt>` to `pip install -r <file.txt>` to correctly install dependencies from a requirements file.