### PR TITLE
Fixes launch error of convert_checkpoint.py script

### DIFF
--- a/src/cerebras/modelzoo/tools/convert_checkpoint.py
+++ b/src/cerebras/modelzoo/tools/convert_checkpoint.py
@@ -28,7 +28,7 @@ from tabulate import tabulate
 
 import cerebras.pytorch as cstorch
 
-sys.path.append(os.path.join(os.path.dirname(__file__), "../"))
+sys.path.append(os.path.join(os.path.dirname(__file__), "../../.."))
 from cerebras.modelzoo.tools.checkpoint_converters.base_converter import (
     BaseCheckpointConverter,
     BaseConfigConverter,


### PR DESCRIPTION
Fixes the path issue that causes the error **"ModuleNotFoundError: No module named 'cerebras.modelzoo'"** while calling the `convert_checkpoint.py `script.


```
Traceback (most recent call last):
  File "convert_checkpoint.py", line 34, in <module>
    from cerebras.modelzoo.tools.checkpoint_converters.base_converter import (
ModuleNotFoundError: No module named 'cerebras.modelzoo'
```