### PR TITLE
fix: apply QK norm in MultiheadAttention hook methods

### DIFF
--- a/src/cerebras/modelzoo/layers/AttentionLayer.py
+++ b/src/cerebras/modelzoo/layers/AttentionLayer.py
@@ -590,11 +590,13 @@ class MultiheadAttention(nn.Module):
         return vector
 
     def process_q_before_logits_calc(self, q):
-        # May get overriden by other attention schemas
+        if self.q_norm is not None:
+            q = self.q_norm(q)
         return q
 
     def process_k_before_logits_calc(self, k):
-        # May get overriden by other attention schemas
+        if self.k_norm is not None:
+            k = self.k_norm(k)
         return k
 
     def process_v_before_logits_calc(self, v):


### PR DESCRIPTION
## Bug
`attention_qk_norm_layer` config instantiates `self.q_norm` and `self.k_norm` in `MultiheadAttention.__init__`, but neither is ever called in the forward pass. QK normalization is silently a no-op.

## Fix
Apply `self.q_norm` / `self.k_norm` inside `process_q_before_logits_calc` and `process_k_before_logits_calc`, so Q and K are normalized before the logits matmul when configured.